### PR TITLE
Add support for 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 Jinja2 = "^3.1.5"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
This PR adds support for python 3.11. The tests passed on python 3.11 so no code change was needed (just metadata change).

This Closes: https://github.com/Effiware/kafka-mocha/issues/25